### PR TITLE
redesign: Alive Design refresh for YKload · Nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,26 +3,39 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>YKload - Nav</title>
+    <meta name="color-scheme" content="dark">
+    <meta name="theme-color" content="#07090f">
+    <title>YKload · Nav</title>
+    <link rel="icon" href="favicon.ico">
+    <link rel="preload" as="font" type="font/woff2" href="MiSans-Light.woff2" crossorigin>
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.font.im/css2?family=Fira+Code&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
 </head>
 <body>
     <div class="background"></div>
-    <div id="wordCloud" class="word-cloud"></div>
+
+    <div class="ambient" aria-hidden="true">
+        <span class="orb orb-a"></span>
+        <span class="orb orb-b"></span>
+        <span class="orb orb-c"></span>
+    </div>
+
+    <div id="wordCloud" class="word-cloud" aria-hidden="true"></div>
+    <div class="grain" aria-hidden="true"></div>
+
     <div class="container">
 
-        <div class="setting">
+        <div class="setting" role="group" aria-label="偏好设置">
             <div class="setting-item">
                 <h1>搜索引擎</h1>
-                                
+
                 <input type="radio" id="baidu" name="searchEngine" value="baidu" checked>
                 <label for="baidu">百度</label>
-                
+
                 <input type="radio" id="bing" name="searchEngine" value="bing">
                 <label for="bing">必应</label>
-                
+
                 <input type="radio" id="google" name="searchEngine" value="google">
                 <label for="google">Google</label>
 
@@ -34,51 +47,52 @@
                 <h1>背景壁纸</h1>
 
                 <input type="radio" id="landscape" name="bg" value="landscape" checked>
-                <label for="landscape">风景 - Bing 日图</label>
-                
+                <label for="landscape">风景 · Bing 日图</label>
+
                 <input type="radio" id="moe" name="bg" value="moe">
-                <label for="moe">萌图 - 次元API</label>
+                <label for="moe">萌图 · 次元API</label>
             </div>
-            
+
             <div class="setting-item">
                 <h1>联想弹幕</h1>
 
                 <input type="radio" id="off" name="danmaku" value="off">
                 <label for="off">关闭</label>
-                
+
                 <input type="radio" id="on" name="danmaku" value="on" checked>
                 <label for="on">开启</label>
             </div>
-
         </div>
-        
-        
-        
-        <div class="time-date">
-            <div id="time"><span id="hours"></span><span id="colon">:</span><span id="minutes"></span></div>
+
+        <div class="time-date" role="button" tabindex="0" aria-label="点击时钟以打开设置">
+            <div id="time">
+                <span id="hours"></span><span id="colon">:</span><span id="minutes"></span>
+            </div>
             <div id="date"></div>
         </div>
+
         <div class="search-container">
-            <div id="focus-hint" class="focus-hint">按 Space 键   |   点此处搜索</div>
+            <div id="focus-hint" class="focus-hint">按 Space   ·   点此处搜索</div>
             <div class="search-bar">
-                <input type="text" id="searchInput" placeholder="要搜什么呢...">
-                <button id="normalSearchBtn" class="search-btn" style="display: flex; justify-content: center; align-items: center;">
-                    <img src="images/Nav-SearchBar.svg" alt="QiuSeek" class="qiuseek-bar" style="width: 100%; height: auto; max-width: 100px; max-height: 100%;">
+                <input type="text" id="searchInput" placeholder="要搜什么呢..." autocomplete="off" spellcheck="false">
+                <button id="normalSearchBtn" class="search-btn" aria-label="使用所选引擎搜索">
+                    <img src="images/Nav-SearchBar.svg" alt="搜索" class="qiuseek-bar">
                 </button>
-                <button id="navBtn" class="search-btn" style="display: flex; justify-content: center; align-items: center;">
-                    <img src="images/YKload-Nav.svg" alt="QiuSeek" class="qiuseek-bar" style="width: 100%; height: auto; max-width: 100px; max-height: 100%;">
+                <button id="navBtn" class="search-btn" aria-label="YKload Nav">
+                    <img src="images/YKload-Nav.svg" alt="YKload Nav" class="qiuseek-bar">
                 </button>
-                <button id="qiuseekBtn" class="search-btn" style="display: flex; justify-content: center; align-items: center;">
-                    <img src="images/Nav-QiuSeekBar.svg" alt="QiuSeek" class="qiuseek-bar" style="width: 100%; height: auto; max-width: 100px; max-height: 100%;">
+                <button id="qiuseekBtn" class="search-btn" aria-label="使用求索 QiuSeek 搜索">
+                    <img src="images/Nav-QiuSeekBar.svg" alt="QiuSeek" class="qiuseek-bar">
                 </button>
             </div>
-            <ul id="suggestions" class="suggestions"></ul>
+            <ul id="suggestions" class="suggestions" role="listbox" aria-label="搜索联想"></ul>
         </div>
     </div>
-    
+
     <footer>
-        <p>&copy; 2024 YKload - Nav. All rights reserved.</p>
+        <p>&copy; 2026 YKload · Nav &nbsp;—&nbsp; Alive&nbsp;Design</p>
     </footer>
+
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,11 +1,19 @@
 // 更新时间和日期
+const WEEKDAYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
+const MONTHS   = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
+
 function updateTimeDate() {
     const now = new Date();
     const hours = String(now.getHours()).padStart(2, '0');
     const minutes = String(now.getMinutes()).padStart(2, '0');
     document.getElementById('hours').textContent = hours;
     document.getElementById('minutes').textContent = minutes;
-    document.getElementById('date').textContent = now.toLocaleDateString();
+
+    const weekday = WEEKDAYS[now.getDay()];
+    const month = MONTHS[now.getMonth()];
+    const day = String(now.getDate()).padStart(2, '0');
+    const year = now.getFullYear();
+    document.getElementById('date').textContent = `${weekday} · ${day} ${month} ${year}`;
 }
 
 setInterval(updateTimeDate, 1000);
@@ -347,6 +355,15 @@ function toggleFocusMode(active) {
     document.querySelector('.time-date').classList.toggle('focus-mode', active);
     document.querySelector('footer').classList.toggle('focus-mode', active);
 
+    const ambient = document.querySelector('.ambient');
+    if (ambient) ambient.classList.toggle('dim', active);
+
+    // 进入焦点模式时清空视差内联 transform，让 CSS 的 scale/blur 接管
+    if (active) {
+        document.querySelector('.background').style.transform = '';
+        if (ambient) ambient.style.transform = '';
+    }
+
     document.querySelector('.setting').classList.remove('open', active);
     
 
@@ -501,3 +518,64 @@ function toggleSearchButtons() {
 
 // 初始化搜索按钮显示状态
 document.addEventListener('DOMContentLoaded', toggleSearchButtons);
+
+// ─── Alive Design 微交互 ─────────────────────────────────
+
+// 指针视差：背景与环境光随鼠标轻微偏移
+(function enablePointerParallax() {
+    if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    const bg = document.querySelector('.background');
+    const ambient = document.querySelector('.ambient');
+    if (!bg && !ambient) return;
+
+    let targetX = 0, targetY = 0;
+    let currentX = 0, currentY = 0;
+    let rafId = null;
+
+    function loop() {
+        currentX += (targetX - currentX) * 0.06;
+        currentY += (targetY - currentY) * 0.06;
+
+        if (bg) {
+            bg.style.transform = `scale(1.04) translate3d(${currentX * -10}px, ${currentY * -10}px, 0)`;
+        }
+        if (ambient) {
+            ambient.style.transform = `translate3d(${currentX * 18}px, ${currentY * 18}px, 0)`;
+        }
+
+        if (Math.abs(targetX - currentX) > 0.001 || Math.abs(targetY - currentY) > 0.001) {
+            rafId = requestAnimationFrame(loop);
+        } else {
+            rafId = null;
+        }
+    }
+
+    window.addEventListener('pointermove', (e) => {
+        if (document.querySelector('.background')?.classList.contains('focus-mode')) return;
+        targetX = (e.clientX / window.innerWidth  - 0.5) * 2;
+        targetY = (e.clientY / window.innerHeight - 0.5) * 2;
+        if (!rafId) rafId = requestAnimationFrame(loop);
+    }, { passive: true });
+})();
+
+// Esc 逃离焦点模式 / 关闭设置
+document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape') return;
+    const setting = document.querySelector('.setting');
+    if (setting && setting.classList.contains('open')) {
+        toggleSettingOpen();
+        return;
+    }
+    if (document.activeElement === searchInput) {
+        searchInput.blur();
+    }
+});
+
+// 让时间区域键盘可达：Enter / Space 也可打开设置
+document.querySelector('.time-date')?.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+        e.preventDefault();
+        toggleSettingOpen();
+    }
+});

--- a/style.css
+++ b/style.css
@@ -1,591 +1,792 @@
 @font-face {
     font-family: 'MiSans';
-    src: url('MiSans-Light.woff2') format('woff2'),
+    src: url('MiSans-Light.woff2') format('woff2');
+    font-display: swap;
+}
 
- }
+:root {
+    --bg-deep: #07090f;
+    --bg-raise: #0d1220;
+    --ink: #e7ecf5;
+    --ink-soft: #c4cfe4;
+    --ink-mute: #8a95ad;
+    --line: rgba(231, 236, 245, 0.10);
+    --line-strong: rgba(231, 236, 245, 0.22);
 
+    --accent-a: #7aa2ff;
+    --accent-b: #b892ff;
+    --accent-c: #68e0ff;
+    --accent-glow: rgba(122, 162, 255, 0.45);
+    --accent-glow-soft: rgba(184, 146, 255, 0.28);
 
-body, html {
+    --glass: rgba(14, 18, 30, 0.38);
+    --glass-strong: rgba(14, 18, 30, 0.62);
+    --glass-border: rgba(255, 255, 255, 0.08);
+
+    --radius-xs: 8px;
+    --radius-sm: 12px;
+    --radius-md: 18px;
+    --radius-lg: 28px;
+    --radius-pill: 999px;
+
+    --spring: cubic-bezier(0.22, 1, 0.36, 1);
+    --swift: cubic-bezier(0.65, 0, 0.35, 1);
+}
+
+* { box-sizing: border-box; }
+
+html, body {
     margin: 0;
     padding: 0;
     height: 100%;
-    font-family: 'MiSans','Fira Code', monospace;
-    color: #A9B7C6;
+    font-family: 'MiSans', 'Fira Code', monospace;
+    color: var(--ink);
+    background-color: var(--bg-deep);
     overflow: hidden;
-    background-color: #646464;
-
     -webkit-user-select: none;
-    -moz-user-select: none; 
-    -ms-user-select: none; 
-    user-select: none; 
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
 }
 
+/* ───── Background image layer ───── */
 .background {
     position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: url(YKload_OST.png) no-repeat center center fixed;
-    background-size: cover;
-    transition: all 0.5s ease;
-    overflow: hidden;
+    inset: 0;
+    background: url(YKload_OST.png) no-repeat center center / cover;
+    transform: scale(1.04);
     opacity: 0;
+    transition:
+        opacity 0.9s var(--swift),
+        filter 0.7s var(--spring),
+        transform 0.9s var(--spring);
+    will-change: transform, filter, opacity;
+    z-index: 0;
 }
 
-.background.fade-in {
-    opacity: 1;
-}
+.background.fade-in { opacity: 1; }
 
 .background::after {
     content: '';
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; 
-    background-color: rgba(0, 0, 0, 0.1); 
-    background-image: radial-gradient(rgba(0, 0, 0, 0) 0, rgba(0, 0, 0, .5) 100%), radial-gradient(rgba(0, 0, 0, 0) 33%, rgba(0, 0, 0, .3) 166%);
+    inset: 0;
+    background:
+        radial-gradient(120% 90% at 50% 100%, rgba(7, 9, 15, 0.85) 0%, rgba(7, 9, 15, 0.30) 55%, transparent 100%),
+        radial-gradient(100% 100% at 50% 0%, rgba(7, 9, 15, 0.55) 0%, transparent 60%),
+        linear-gradient(180deg, rgba(7, 9, 15, 0.35), rgba(7, 9, 15, 0.55));
     z-index: 1;
 }
 
+.background.focus-mode {
+    filter: blur(18px) saturate(1.1) brightness(0.78);
+    transform: scale(1.14);
+}
 
+/* ───── Ambient orbs ───── */
+.ambient {
+    position: fixed;
+    inset: -10%;
+    pointer-events: none;
+    z-index: 0;
+    overflow: hidden;
+    mix-blend-mode: screen;
+    opacity: 0.85;
+    transition: opacity 0.6s var(--swift), transform 0.4s var(--spring);
+}
 
+.ambient .orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(80px);
+    opacity: 0.55;
+    will-change: transform;
+}
+
+.ambient .orb-a {
+    width: 520px; height: 520px;
+    left: -8%; top: -10%;
+    background: radial-gradient(circle at 30% 30%, var(--accent-a), transparent 65%);
+    animation: driftA 22s ease-in-out infinite alternate;
+}
+.ambient .orb-b {
+    width: 620px; height: 620px;
+    right: -12%; top: 20%;
+    background: radial-gradient(circle at 70% 40%, var(--accent-b), transparent 65%);
+    animation: driftB 28s ease-in-out infinite alternate;
+}
+.ambient .orb-c {
+    width: 480px; height: 480px;
+    left: 30%; bottom: -18%;
+    background: radial-gradient(circle at 50% 50%, var(--accent-c), transparent 65%);
+    animation: driftC 32s ease-in-out infinite alternate;
+}
+
+@keyframes driftA {
+    0%   { transform: translate(0, 0) scale(1); }
+    100% { transform: translate(80px, 60px) scale(1.1); }
+}
+@keyframes driftB {
+    0%   { transform: translate(0, 0) scale(1.05); }
+    100% { transform: translate(-90px, 40px) scale(0.95); }
+}
+@keyframes driftC {
+    0%   { transform: translate(0, 0) scale(0.95); }
+    100% { transform: translate(60px, -50px) scale(1.1); }
+}
+
+.ambient.dim { opacity: 0.35; }
+
+/* ───── Grain texture ───── */
+.grain {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 2;
+    opacity: 0.055;
+    mix-blend-mode: overlay;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.6 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+}
+
+/* ───── Container ───── */
 .container {
     position: relative;
-    z-index: 1;
+    z-index: 3;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
     height: 100%;
-    background-color: transparent;
-    transition: all 0.3s ease-out;
+    padding: 0 24px;
+    transition: backdrop-filter 0.45s var(--swift), background-color 0.45s var(--swift);
 }
 
 .container.focus-mode {
-    background-color: rgba(43, 43, 43, 0.7);
+    background-color: rgba(7, 9, 15, 0.42);
+    backdrop-filter: blur(2px);
 }
 
+/* ───── Clock ───── */
 .time-date {
-    color: #ffffff;
-    font-family: 'Fira Code';
+    font-family: 'Fira Code', 'MiSans', monospace;
+    color: var(--ink);
     text-align: center;
-    margin-bottom: 2rem;
+    margin-bottom: 2.25rem;
     opacity: 0;
-    transform: translateY(-20px);
-    animation: fadeInDown 0.5s ease forwards;
-    transition: all 0.3s ease;
+    transform: translateY(-16px);
+    animation: rise 0.9s var(--spring) forwards;
+    transition: color 0.4s var(--swift), transform 0.4s var(--swift), opacity 0.4s var(--swift);
+    cursor: pointer;
 }
 
 .time-date.focus-mode {
-    color: #A9B7C6;
+    opacity: 0.55;
+    transform: translateY(-6px) scale(0.96);
+    color: var(--ink-soft);
 }
 
 #time {
     display: flex;
-    font-size: 3.5rem;
-    text-shadow: 0px 0px 10px #A9B7C6;
-    transition: all 0.15s ease-out;
+    justify-content: center;
+    align-items: baseline;
+    font-size: clamp(3.5rem, 8vw, 5.5rem);
+    font-weight: 300;
+    letter-spacing: 0.04em;
+    line-height: 1;
+    color: #ffffff;
+    text-shadow:
+        0 0 24px rgba(122, 162, 255, 0.35),
+        0 0 80px rgba(184, 146, 255, 0.18);
+    animation: breathe 6s ease-in-out infinite;
+    transition: transform 0.25s var(--spring), text-shadow 0.3s var(--swift), filter 0.3s var(--swift);
+    will-change: transform, text-shadow;
 }
 
 #time:hover {
-    text-shadow: 0px 0px 20px #A9B7C6; 
-    filter: brightness(1.5);
+    text-shadow:
+        0 0 36px rgba(122, 162, 255, 0.55),
+        0 0 110px rgba(184, 146, 255, 0.28);
+    filter: brightness(1.1);
 }
 
 #time:active {
-    text-shadow: 0px 0px 5px #A9B7C6; 
-    transform: scale(0.9); 
+    transform: scale(0.97);
+}
+
+#hours, #minutes {
+    font-variant-numeric: tabular-nums;
+}
+
+#colon {
+    margin: 0 0.12em;
+    animation: blink 1.2s ease-in-out infinite;
+    font-family: 'Fira Code', monospace;
+    color: var(--accent-a);
+    text-shadow: 0 0 18px var(--accent-glow);
 }
 
 #date {
-    font-size: 1.5rem;
-    opacity: 0.7;
-    text-shadow: 0px 0px 5px #A9B7C6;
+    margin-top: 0.45rem;
+    font-size: 1rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--ink-mute);
+    font-weight: 300;
+    text-shadow: 0 0 14px rgba(138, 149, 173, 0.22);
 }
 
-
-#colon {
-    font-family: math;
-    animation: blink 1s infinite;
-}
-
+/* ───── Search area ───── */
 .search-container {
-    width: 230px;
-    max-width: 600px;
+    position: relative;
+    width: min(560px, 92vw);
     opacity: 0;
-    transform: translateY(20px);
-    animation: fadeInUp 0.5s ease forwards 0.3s;
-    transition: all 0.3s ease-out;
+    transform: translateY(18px);
+    animation: rise 0.9s var(--spring) 0.15s forwards;
+    transition: width 0.5s var(--spring), transform 0.4s var(--spring);
 }
 
-.search-container.focus-mode {
-    width: 80%;
+.search-container.focus-mode { width: min(720px, 92vw); }
+
+/* Focus hint (the placeholder chip shown while unfocused) */
+.focus-hint {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    padding: 10px 22px;
+    border-radius: var(--radius-pill);
+    color: var(--ink);
+    font-size: 0.92rem;
+    letter-spacing: 0.14em;
+    background: rgba(15, 20, 34, 0.55);
+    backdrop-filter: blur(14px) saturate(1.3);
+    -webkit-backdrop-filter: blur(14px) saturate(1.3);
+    border: 1px solid var(--glass-border);
+    box-shadow:
+        0 8px 30px rgba(0, 0, 0, 0.35),
+        inset 0 1px 0 rgba(255, 255, 255, 0.07);
+    white-space: pre;
+    pointer-events: none;
+    z-index: 4;
+    transition: transform 0.5s var(--spring), opacity 0.4s var(--swift), filter 0.4s var(--swift);
 }
 
+.focus-hint::before {
+    content: '';
+    position: absolute;
+    inset: -1px;
+    padding: 1px;
+    border-radius: inherit;
+    background: linear-gradient(120deg, transparent 20%, rgba(122, 162, 255, 0.4), transparent 80%);
+    -webkit-mask: linear-gradient(#000, #000) content-box, linear-gradient(#000, #000);
+    mask: linear-gradient(#000, #000) content-box, linear-gradient(#000, #000);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.focus-hint.focus-mode {
+    transform: translate(-50%, 0%);
+    opacity: 0;
+    filter: blur(18px);
+}
+
+/* Search bar — glass pill */
 .search-bar {
-    width: 100%;
-    max-width: 600px;
+    position: relative;
     display: flex;
-    /* margin-bottom: 0px; */
-    transition: all 0.3s ease-out;
+    align-items: center;
+    width: 100%;
+    padding: 6px;
+    border-radius: var(--radius-pill);
+    background: var(--glass);
+    backdrop-filter: blur(18px) saturate(1.4);
+    -webkit-backdrop-filter: blur(18px) saturate(1.4);
+    border: 1px solid var(--glass-border);
+    box-shadow:
+        0 20px 50px rgba(0, 0, 0, 0.45),
+        inset 0 1px 0 rgba(255, 255, 255, 0.06);
     opacity: 0;
     color: transparent;
-    pointer-events: visible;
-    background-color: transparent;
-    box-shadow: 0px 25px 25px #a9b7c670;
+    transition:
+        opacity 0.4s var(--swift),
+        transform 0.4s var(--spring),
+        box-shadow 0.45s var(--swift),
+        border-color 0.4s var(--swift);
 }
 
-.search-bar:hover {
-    opacity: 1;
-}
+.search-bar:hover { opacity: 1; }
 
 .search-bar.focus-mode {
     opacity: 1;
-    color: #A9B7C6;
+    color: var(--ink);
+    border-color: rgba(122, 162, 255, 0.35);
+    box-shadow:
+        0 24px 70px rgba(0, 0, 0, 0.55),
+        0 0 0 4px rgba(122, 162, 255, 0.10),
+        inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
-  
+/* Animated aurora glow behind the bar */
+.search-bar::before {
+    content: '';
+    position: absolute;
+    inset: -2px;
+    border-radius: inherit;
+    background: conic-gradient(
+        from 0deg,
+        var(--accent-a),
+        var(--accent-c),
+        var(--accent-b),
+        var(--accent-a)
+    );
+    filter: blur(22px);
+    opacity: 0;
+    z-index: -1;
+    transition: opacity 0.6s var(--swift);
+    animation: spin 18s linear infinite;
+}
+
+.search-bar.focus-mode::before { opacity: 0.35; }
 
 #searchInput {
-    font-family: 'MiSans','Fira Code', monospace;
-    flex-grow: 1;
-    padding: 10px;
-    font-size: 1rem;
-    background-color: #2b2b2b00;
+    font-family: 'MiSans', 'Fira Code', monospace;
+    flex: 1;
+    min-width: 0;
+    padding: 14px 20px;
+    font-size: 1.05rem;
+    letter-spacing: 0.02em;
+    background: transparent;
     color: transparent;
-    border: 0px solid #646464;
-    transition: all 0.3s ease-out;
-    z-index: 1;
-}
-
-#searchInput:hover {
-    box-shadow: 0px 0px 25px #a9b7c670;
-    filter: brightness(1.5);
+    border: 0;
+    outline: none;
+    transition: color 0.3s var(--swift);
+    caret-color: var(--accent-a);
 }
 
 #searchInput::placeholder {
+    color: var(--ink-mute);
     opacity: 0;
+    transition: opacity 0.3s var(--swift);
 }
 
-#searchInput:focus::placeholder {
-    opacity: 1;
-}
+#searchInput:focus::placeholder { opacity: 1; }
 
-#searchInput:focus, #searchEngine:focus {
-    outline: none;
-    color: #A9B7C6;
-
-}
+#searchInput:focus { color: var(--ink); }
 
 #searchInput::selection {
-    background-color: #a9b7c698;
-    color: #000;
+    background-color: rgba(122, 162, 255, 0.45);
+    color: #fff;
 }
 
+/* Search buttons — pill segments */
 .search-btn {
-    font-family: 'MiSans','Fira Code', monospace;
-    font-size: 1rem;
-    background-color: #2b2b2b00;
-    color: #A9B7C6;
-    border: none;
+    font-family: 'MiSans', 'Fira Code', monospace;
+    height: 44px;
+    border: 0;
+    border-radius: var(--radius-pill);
+    background: transparent;
+    color: var(--ink);
     cursor: pointer;
-    transition: all 0.3s ease-out;
-
-    width: 0px;
-    pointer-events: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 14px;
+    margin-left: 4px;
+    width: 0;
     opacity: 0;
-    transition: all 0.3s ease-out;
-}
-
-.search-btn i {
-    font-size: 1.2rem;
+    pointer-events: none;
+    overflow: hidden;
+    transition:
+        width 0.4s var(--spring),
+        opacity 0.35s var(--swift),
+        background-color 0.25s var(--swift),
+        transform 0.25s var(--spring),
+        box-shadow 0.25s var(--swift);
 }
 
 .search-btn:hover {
-    filter: brightness(1.5);
+    background: rgba(122, 162, 255, 0.14);
+    box-shadow: 0 0 24px rgba(122, 162, 255, 0.25);
+    transform: translateY(-1px);
 }
 
-.search-btn:active {
-    filter: brightness(1.5);
-}
+.search-btn:active { transform: translateY(0) scale(0.96); }
 
+.search-btn img { pointer-events: none; max-height: 22px; width: auto; }
+
+/* ───── Suggestions ───── */
 .suggestions {
-    list-style-type: none;
+    list-style: none;
     padding: 0;
-    margin: 0;
-    background-color: #2b2b2b8c;
-    /* border: 1px solid #646464; */
-    height: 0px;
-    /* max-height: 0px; */
-    overflow-y: auto;
-    display: block;
-    visibility: visible;
-    transition: all 0.5s ease;
+    margin: 14px 0 0;
+    height: 0;
+    max-height: 60vh;
     overflow: hidden;
-    /* box-shadow: 0px 0px 25px #a9b7c670; */
+    border-radius: var(--radius-md);
+    background: rgba(11, 14, 26, 0.55);
+    backdrop-filter: blur(18px) saturate(1.3);
+    -webkit-backdrop-filter: blur(18px) saturate(1.3);
+    border: 1px solid var(--glass-border);
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    transition:
+        height 0.45s var(--spring),
+        opacity 0.35s var(--swift),
+        transform 0.4s var(--spring);
+    transform: translateY(-4px);
 }
 
+.search-container.focus-mode .suggestions {
+    transform: translateY(0);
+}
 
 .suggestion-item {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    max-height: 20px;
-    padding: 10px;
+    gap: 10px;
+    height: 40px;
+    padding: 0 18px;
     cursor: pointer;
-    position: relative;
-    transition: all 0.3s ease-out;
+    color: var(--ink-soft);
+    transition:
+        color 0.25s var(--swift),
+        letter-spacing 0.25s var(--swift),
+        padding-left 0.3s var(--spring);
+    overflow: hidden;
 }
 
 .suggestion-item::before {
     content: '';
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 0; 
-    height: 100%;
-    background-color: #c4e0ff9d;
-    box-shadow: 0px 0px 25px #c4e0ff9d;
-    z-index: 0;
-    transition: all 0.3s ease-out;
-    opacity: 0.35;
-}
-
-.suggestion-item.selected::before,
-.suggestion-item:hover::before {
-    width: 100%; 
+    top: 50%;
+    left: 10px;
+    width: 0;
+    height: 18px;
+    border-radius: 2px;
+    background: linear-gradient(180deg, var(--accent-a), var(--accent-b));
+    box-shadow: 0 0 12px var(--accent-glow);
+    transform: translateY(-50%);
+    transition: width 0.3s var(--spring);
 }
 
 .suggestion-item.selected,
 .suggestion-item:hover {
-    filter: brightness(1.2);
-    color: #d7eaff;
-    text-shadow: 0px 0px 2px #A9B7C6;
-    letter-spacing: 3px;
+    color: #ffffff;
+    letter-spacing: 0.06em;
+    padding-left: 28px;
 }
 
-footer {
-    font-family: 'Fira Code';
-    color: rgba(255, 255, 255, 0.6);
-    position: fixed;
-    bottom: 0;
-    width: 100%;
-    text-align: center;
-    padding: 10px;
-    /* background-color: rgba(43, 43, 43, 0.7); */
-    opacity: 0;
-    animation: fadeIn 0.5s ease forwards 0.6s;
-    transition: all 0.3s ease;
-    z-index: 1;
-    text-shadow: 0px 0px 5px #A9B7C6;
+.suggestion-item.selected::before,
+.suggestion-item:hover::before {
+    width: 3px;
 }
 
-footer.focus-mode {
-    color: #a9b7c6b5;
-}
+.suggestion-item.fade-out { opacity: 0; transform: translateY(-4px); }
 
-@keyframes fadeInDown {
-    from {
-        opacity: 0;
-        transform: translateY(-20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes fadeInUp {
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
-}
-
-@keyframes blink {
-    0% { opacity: 1; }
-    90% { opacity: 0.05; }
-    100% { opacity: 1; }
-}
-
-.fade-out {
-    opacity: 0;
-}
-
-.background.focus-mode {
-    filter: blur(7px);
-    transform: scale(1.17);
-}
-
-.word-cloud {
-    filter: blur(2px);
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-    z-index: 0;
+.suggestion-text {
+    flex: 1;
+    min-width: 0;
     overflow: hidden;
-    transition: all 0.3s ease;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    margin-right: 10px;
+    z-index: 1;
+}
+
+.suggestion-btn {
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    padding: 4px 6px;
+    border-radius: var(--radius-xs);
+    display: inline-flex;
+    align-items: center;
+    opacity: 0.55;
+    transition: opacity 0.2s var(--swift), transform 0.2s var(--spring), background-color 0.2s var(--swift);
+}
+
+.suggestion-btn:hover {
+    opacity: 1;
+    background: rgba(122, 162, 255, 0.12);
+}
+
+.suggestion-btn:active { transform: scale(0.92); }
+
+.qiuseek-icon { width: 18px; height: 18px; display: block; }
+.qiuseek-bar  { max-height: 20px; width: auto; display: block; }
+
+/* ───── Footer ───── */
+footer {
+    position: fixed;
+    bottom: 14px;
+    left: 0;
+    right: 0;
+    text-align: center;
+    padding: 8px 12px;
+    font-family: 'Fira Code', monospace;
+    font-size: 0.78rem;
+    letter-spacing: 0.18em;
+    color: rgba(231, 236, 245, 0.45);
+    z-index: 3;
+    opacity: 0;
+    animation: rise 0.9s var(--spring) 0.35s forwards;
+    transition: color 0.4s var(--swift), opacity 0.4s var(--swift);
+}
+
+footer.focus-mode { color: rgba(231, 236, 245, 0.25); }
+
+/* ───── Word cloud (danmaku) ───── */
+.word-cloud {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 1;
+    overflow: hidden;
+    opacity: 0;
+    filter: blur(2px);
+    transition: opacity 0.45s var(--swift);
+    mix-blend-mode: screen;
 }
 
 .word-cloud-row {
     position: absolute;
-    white-space: nowrap;
-    opacity: 0.25;
-    color: #fff;
-    font-size: 25px;
-    text-shadow: 0px 0px 3px rgb(192 241 255);
+    white-space: pre;
+    opacity: 0.22;
+    color: #eaf2ff;
+    font-size: 22px;
+    font-weight: 300;
+    letter-spacing: 0.1em;
+    text-shadow:
+        0 0 8px rgba(122, 162, 255, 0.45),
+        0 0 24px rgba(184, 146, 255, 0.22);
     animation-name: slideLeft;
     animation-timing-function: linear;
     animation-iteration-count: infinite;
 }
 
-.word-cloud-row:nth-child(even) {
-    animation-name: slideRight;
-}
+.word-cloud-row:nth-child(even) { animation-name: slideRight; }
 
-
-@keyframes slideLeft {
-    from { transform: translateX(0); }
-    to { transform: translateX(-100%); }
-}
-
-@keyframes slideRight {
-    from { transform: translateX(-100%); }
-    to { transform: translateX(0); }
-}
-
-
-
-
-.focus-hint {
-    height: 31px;
-    align-content: center;
-    text-align: center;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    padding: 5px;
-    padding-inline: 10px;
-    background-color: #91a2b3d1;
-    color: #fff;
-    z-index: 1000;
-    transition: opacity 0.3s;
-    opacity: 1;
-    pointer-events: none;
-    transition: all 0.3s ease;
-    width: 210px;
-    max-width: 600px;
-    filter: blur(0px);
-    white-space: pre;
-    box-shadow: 0px 0px 25px #A9B7C6;
-}
-
-.focus-hint:hover {
-    background-color: #91a2b3;
-    filter: brightness(1.5);
-}
-
-.focus-hint.focus-mode {
-    background-color: #a9b7c62d;
-    color: #A9B7C6;
-    transform: translate(-50%, 0%);
-    width: 600px;
-    opacity: 0;
-    filter: blur(25px);
-}
-
+/* ───── Search overlay (navigation fade) ───── */
 .search-overlay {
     position: fixed;
-    top: 0%;
-    left: 0%;
-    width: 100%;
-    height: 100%;
-    background-color: rgb(255, 255, 255);
-    color: #A9B7C6;
-    font-size: 24px;
+    inset: 0;
     display: flex;
-    justify-content: center;
     align-items: center;
+    justify-content: center;
+    background: radial-gradient(ellipse at center, rgba(122, 162, 255, 0.18), rgba(7, 9, 15, 0.96) 70%);
     opacity: 0;
-    transition: all 0.3s ease-in-out;
     z-index: 1000;
-    transform-origin: center center;
+    transition: opacity 0.35s var(--swift);
+    pointer-events: none;
 }
 
-.search-overlay.visible {
-    opacity: 1;
-}
+.search-overlay.visible { opacity: 1; }
 
-
+/* ───── Settings drawer ───── */
 .setting {
     display: flex;
     flex-direction: column-reverse;
+    gap: 8px;
     height: 0;
-    width: 100%;
-    max-width: 700px;
-    margin: 20px auto;
-    background-color: transparent;
-    /* border-radius: 25px; */
-    /* padding: 10px; */
-    color: #A9B7C6;
+    width: min(720px, 92vw);
+    margin: 24px auto;
+    padding: 0 16px;
+    color: var(--ink-soft);
+    background: rgba(11, 14, 26, 0);
+    backdrop-filter: blur(0px);
+    -webkit-backdrop-filter: blur(0px);
+    border-radius: var(--radius-lg);
+    border: 1px solid transparent;
     overflow: hidden;
-    transition: all 0.3s ease-in-out;
-    transform-origin: bottom center;
     opacity: 0;
+    transform-origin: bottom center;
+    transition:
+        height 0.5s var(--spring),
+        opacity 0.45s var(--swift),
+        background-color 0.45s var(--swift),
+        border-color 0.45s var(--swift),
+        backdrop-filter 0.45s var(--swift);
 }
 
 .setting.open {
     opacity: 1;
-    height: 202px;
-    background-color: #2b2b2b8c;
+    height: auto;
+    min-height: 260px;
+    padding: 18px;
+    background: rgba(11, 14, 26, 0.55);
+    border-color: var(--glass-border);
+    backdrop-filter: blur(18px) saturate(1.3);
+    -webkit-backdrop-filter: blur(18px) saturate(1.3);
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
 }
-
-
 
 .setting-item {
     position: relative;
-    display: flex;
+    display: grid;
+    grid-template-columns: 120px 1fr;
     align-items: center;
-    padding: 10px;
+    gap: 16px;
+    padding: 8px 6px;
+    border-radius: var(--radius-md);
 }
 
 .setting-item h1 {
     margin: 0;
-    padding-inline: 10px;
-    padding-right: 20px;
-    font-size: 1.5em;
-    font-weight: normal;
-    color: #d7eaff;
-    text-shadow: 0px 0px 5px #A9B7C6;
+    padding: 0 4px;
+    font-size: 0.78rem;
+    font-weight: 400;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: var(--ink-mute);
 }
 
-.setting input[type="radio"] {
-    display: none;
+.setting input[type="radio"] { display: none; }
+
+/* Segmented control look */
+.setting-item {
+    --seg-bg: rgba(255, 255, 255, 0.04);
+}
+
+.setting-item::after {
+    content: none;
 }
 
 .setting label {
-    justify-content: center;
-    display: flex;
-    align-items: center;
-    height: 27px;
-    flex: 1; /* 让标签占据剩余空间 */
-    padding: 10px 0;
-    text-align: center;
-    cursor: pointer;
     position: relative;
-    z-index: 2;
-    /* border-radius: 15px; */
-    transition: all 0.3s ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 38px;
+    padding: 0 16px;
+    margin: 2px;
+    font-size: 0.9rem;
+    letter-spacing: 0.02em;
+    color: var(--ink-soft);
+    background: rgba(255, 255, 255, 0.035);
+    border: 1px solid transparent;
+    border-radius: var(--radius-pill);
+    cursor: pointer;
+    overflow: hidden;
+    transition:
+        color 0.25s var(--swift),
+        background-color 0.25s var(--swift),
+        border-color 0.25s var(--swift),
+        transform 0.25s var(--spring),
+        letter-spacing 0.25s var(--swift),
+        box-shadow 0.25s var(--swift);
 }
 
 .setting label::before {
     content: '';
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 0; 
-    height: 100%;
-    background-color: #c4e0ff9d; /* 背景颜色 */
-    box-shadow: 0px 0px 10px #c4e0ff9d;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(122, 162, 255, 0.22), rgba(184, 146, 255, 0.22));
+    opacity: 0;
+    transition: opacity 0.25s var(--swift);
     z-index: 0;
-    transition: all 0.3s ease-out; /* 宽度过渡效果 */
-    opacity: 0.35;
 }
 
-.setting label.selected::before,
-.setting label:hover::before {
-    width: 100%; 
+.setting label > * { position: relative; z-index: 1; }
 
+.setting label:hover {
+    color: #ffffff;
+    border-color: rgba(255, 255, 255, 0.14);
+    transform: translateY(-1px);
 }
+
+.setting label:hover::before { opacity: 0.45; }
 
 .setting label.selected,
-.setting label:hover {
-
-    color: #d7eaff;
-    text-shadow: 0px 0px 5px #A9B7C6;
-    filter: brightness(1.2);
-    letter-spacing: 3px;
-}
-
-/* 选中标签的颜色 */
 .setting-item input:checked + label {
-    color: #d7eaff;
-    text-shadow: 0px 0px 5px #A9B7C6;
-    background-color: #7f95afd4;
-    box-shadow: 0px 0px 10px #7f95afd4;
+    color: #ffffff;
+    border-color: rgba(122, 162, 255, 0.55);
+    background: linear-gradient(120deg, rgba(122, 162, 255, 0.28), rgba(184, 146, 255, 0.28));
+    box-shadow:
+        0 8px 24px rgba(122, 162, 255, 0.25),
+        inset 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 
+/* Wrap options as a flex group */
+.setting-item > input[type="radio"] + label {
+    /* labels flow to the right of h1 */
+}
 
+/* Place labels in a wrapping flex row next to the heading */
+.setting-item {
+    flex-wrap: wrap;
+}
 
-/* 动画效果 */
+@supports (display: grid) {
+    .setting-item {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+    .setting-item h1 { min-width: 88px; }
+}
+
+/* ───── Keyframes ───── */
+@keyframes rise {
+    from { opacity: 0; transform: translateY(18px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
 @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(-10px); }
-    to { opacity: 1; transform: translateY(0); }
+    from { opacity: 0; }
+    to   { opacity: 1; }
 }
 
-.setting {
-    animation: fadeIn 0.5s ease-out;
+@keyframes blink {
+    0%, 100% { opacity: 1; }
+    45%      { opacity: 0.15; }
+    55%      { opacity: 0.15; }
 }
 
-.qiuseek-bar {
-    width: 100px;
-    height: 20px;
-    transition: all 0.3s ease-out;
+@keyframes breathe {
+    0%, 100% { transform: scale(1);    filter: brightness(1); }
+    50%      { transform: scale(1.012); filter: brightness(1.06); }
 }
 
-.qiuseek-icon {
-    width: 20px;
-    height: 20px;
-    transition: all 0.3s ease-out;
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to   { transform: rotate(360deg); }
 }
 
-.qiuseek-btn {
-    filter: brightness(1);
-    transition: all 0.3s ease-out;
+@keyframes slideLeft {
+    from { transform: translateX(0); }
+    to   { transform: translateX(-100%); }
 }
 
-.qiuseek-btn:hover {
-    filter: brightness(1.5);
+@keyframes slideRight {
+    from { transform: translateX(-100%); }
+    to   { transform: translateX(0); }
 }
 
-
-.search-btn:hover .qiuseek-icon .qiuseek-bar,
-.suggestion-btn:hover .qiuseek-icon .qiuseek-bar {
-    filter: brightness(1.5);
+/* ───── Responsive ───── */
+@media (max-width: 560px) {
+    #time { font-size: 3.4rem; }
+    #date { font-size: 0.85rem; letter-spacing: 0.18em; }
+    .search-container { width: 94vw; }
+    .search-container.focus-mode { width: 96vw; }
+    .focus-hint { font-size: 0.82rem; padding: 8px 16px; }
+    .setting-item { flex-direction: column; align-items: flex-start; }
+    .setting-item h1 { margin-bottom: 4px; }
+    footer { font-size: 0.68rem; }
 }
 
-.search-btn:active .qiuseek-icon .qiuseek-bar,
-.suggestion-btn:active .qiuseek-icon .qiuseek-bar {
-    transform: scale(0.9);
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.15s !important;
+    }
+    #time { animation: none; }
+    .search-bar::before { animation: none; }
+    .ambient .orb { animation: none; }
 }
-
-.suggestion-btn {
-    z-index: 2;
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 5px;
-}
-
-.suggestion-text {
-    flex-grow: 1;
-    z-index: 1;
-    margin-right: 10px;
-}
-
-


### PR DESCRIPTION
## Summary

重新诠释 YKload · Nav 起始页的界面与体验，注入"Alive Design"的呼吸感与层次感，同时完整保留既有功能（多搜索引擎、求索 QiuSeek 长按 Enter、联想弹幕、背景切换、设置持久化、Space 聚焦快捷键）。

### 视觉 & 交互改动

- **环境光层 (ambient orbs)**：三颗缓慢漂移、混合色的辉光球，带指针视差
- **胶片噪点 + 分层暗角**：给画面增加空气感与纵深
- **呼吸时钟**：缓慢呼吸的缩放与光晕，冒号取"跳动"脉冲；日期改为 `SUN · 19 APR 2026` 的优雅大写排印
- **玻璃搜索胶囊**：`backdrop-filter` 毛玻璃，聚焦时出现锥形极光描边
- **分段控件式设置**：胶囊按钮 + 渐变选中态 + 柔和投影
- **流畅联想列表**：左侧渐变指示条 + 缓动入场，选中时轻微缩进
- **键盘可达性**：时钟 `Enter` 打开设置，`Esc` 退出聚焦 / 关闭设置
- **响应式 + `prefers-reduced-motion`** 适配

### 技术备注

- 所有 DOM ID / class 与 `script.js` 旧约定完全兼容（`#searchInput`、`#normalSearchBtn`、`#qiuseekBtn`、`#navBtn`、`.setting`、`input[name="searchEngine|bg|danmaku"]` 等）
- JS 仅做增量增强：日期格式化、聚焦模式联动 ambient、指针视差 rAF 循环、Esc 逃离
- CSS 加入 CSS 变量体系 (`--accent-a/b/c`、`--glass`、`--spring`) 便于后续主题扩展

## Test plan

- [ ] 浏览器打开 `index.html`，确认时钟呼吸、冒号脉冲
- [ ] 鼠标移动时背景与环境光柔和视差
- [ ] 按 `Space` 聚焦搜索框：玻璃胶囊浮出，极光描边出现
- [ ] 输入文字：显示联想列表，方向键上下导航，`Enter` 搜索、长按 `Enter` 触发 QiuSeek
- [ ] 点击时钟：设置抽屉从底部玻璃化展开，分段控件切换生效并持久化
- [ ] `Esc` 关闭聚焦 / 设置
- [ ] 窄屏（<560px）布局降级合理
- [ ] `prefers-reduced-motion` 下动画减弱

https://claude.ai/code/session_01VHLQfmPdqFuZySbn9bZkbn